### PR TITLE
Add docsearch scrapper to run on closed PRs

### DIFF
--- a/.github/workflows/docsearch-scraper.yml
+++ b/.github/workflows/docsearch-scraper.yml
@@ -1,0 +1,20 @@
+name: Devportal Scraper
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  devportal-scraper:
+    runs-on: ubuntu-latest
+    name: Run scraper_openapi and scraper_md
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Devportal Scraper
+      uses: vtexdocs/devportal-docsearch-action@main
+      with:
+        algolia_application_id: '${{ secrets.ALGOLIA_APP_ID }}'
+        algolia_api_key: ${{ secrets.ALGOLIA_WRITE_KEY }}
+        files: './configs/scraper_md.json'

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useContext, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
 import { HamburgerMenu } from '@vtexdocs/components'
-// import { SearchInput } from '@vtexdocs/components'
+import { SearchInput } from '@vtexdocs/components'
 import DropdownMenu from 'components/dropdown-menu'
 import GridIcon from 'components/icons/grid-icon'
 import LongArrowIcon from 'components/icons/long-arrow-icon'
@@ -107,9 +107,9 @@ const Header = () => {
           <ContentPortalIcon sx={styles.logoSize} />
         </VtexLink>
 
-        {/* <Box sx={styles.searchContainer}>
+        <Box sx={styles.searchContainer}>
           <SearchInput />
-        </Box> */}
+        </Box>
 
         <HeaderBrand.RightLinks sx={styles.rightLinks}>
           <Flex


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Add docsearch scrapper to run on closed PRs;
- Uncomment Search component to make it visible in the UI.

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
